### PR TITLE
ansible: avoid lvmcluster tasks for empty cluster name

### DIFF
--- a/ansible/books/lvmcluster.yaml
+++ b/ansible/books/lvmcluster.yaml
@@ -32,6 +32,7 @@
       template:
         src: "../files/lvmcluster/host_id.yaml.tpl"
         dest: "../data/lvmcluster/{{ task_name }}/host_id.yaml"
+      when: 'task_name'
       vars:
         task_host_ids: "{{ lookup('file', '../data/lvmcluster/' + task_name + '/host_id.yaml') | from_yaml }}"
 
@@ -57,6 +58,7 @@
       template:
         src: ../files/lvmcluster/lvmlocal.conf.tpl
         dest: /etc/lvm/lvmlocal.conf
+      when: 'task_name'
 
 - name: LVM Cluster - Create VGs
   hosts: all
@@ -70,7 +72,7 @@
       shell:
         cmd: "vgs {{ item }}"
       register: check
-      loop: "{{ lvmcluster_vgs.keys() }}"
+      loop: "{{ task_vgs.keys() }}"
       run_once: true
       changed_when: false
       failed_when: "check.rc not in (0, 5)"


### PR DESCRIPTION
If `lvmcluster_name` is empty some lvmcluster tasks still try to execute.