### PR TITLE
Ensure NTP is successfully synced on all servers

### DIFF
--- a/ansible/books/env-checks.yaml
+++ b/ansible/books/env-checks.yaml
@@ -1,0 +1,11 @@
+---
+- name: Environment checks
+  hosts: all
+  order: shuffle
+  any_errors_fatal: true
+  tasks:
+    - name: Verify NTP successfully synced
+      shell:
+        cmd: timedatectl timesync-status
+      register: ntp_status_output
+      failed_when: '"Packet count: 0" in ntp_status_output.stdout'

--- a/ansible/deploy.yaml
+++ b/ansible/deploy.yaml
@@ -1,3 +1,4 @@
+- import_playbook: books/env-checks.yaml
 - import_playbook: books/ceph.yaml
 - import_playbook: books/lvmcluster.yaml
 - import_playbook: books/ovn.yaml


### PR DESCRIPTION
If time isn't synchronized across the cluster, clock skew can lead to certificate validity issues when trying to join new servers to the cluster.