### PR TITLE
Fix lvm config name in hosts.yaml.example

### DIFF
--- a/ansible/hosts.yaml.example
+++ b/ansible/hosts.yaml.example
@@ -63,7 +63,7 @@ all:
             shared:
               driver: lvmcluster
               local_config:
-                lvm.vg.name: "vg0"
+                lvm.vg_name: "vg0"
                 source: "vg0"
               default: true
               description: Shared storage pool (cluster-wide)


### PR DESCRIPTION
Fix lvm config name in hosts.yaml.example. It is `lvm.vg.name` and it should be `lvm.vg_name`