### PR TITLE
ansible: Run ceph commands remotely

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,8 +36,6 @@ jobs:
         run: |
           sudo apt-get install --no-install-recommends --yes \
             ansible \
-            ceph-base \
-            ceph-common \
             python3-jmespath
 
       - name: Setup Incus

--- a/README.md
+++ b/README.md
@@ -8,11 +8,6 @@ Install Incus stable or LTS on your system from the [zabbly/incus](https://githu
 
 Install [OpenTofu](https://opentofu.org/docs/intro/install/).
 
-Install the required ceph packages for Ansible on the controller, on Debian that's the `ceph-base` and `ceph-common` packages:
-```
-apt install --no-install-recommends ceph-base ceph-common
-```
-
 ### Create the test VMs with OpenTofu
 Go to terraform directory:
 ```

--- a/ansible/books/ceph.yaml
+++ b/ansible/books/ceph.yaml
@@ -174,7 +174,6 @@
 
 - name: Ceph - Generate cluster keys and maps
   hosts: all
-  order: shuffle
   gather_facts: yes
   gather_subset:
     - "default_ipv4"
@@ -199,57 +198,162 @@
       squid: 19
   any_errors_fatal: true
   tasks:
-    - name: Generate mon keyring
+    - name: Check if bootstrap server
+      meta: end_host
+      when: "lookup('template', '../files/ceph/ceph.monitors.names.tpl') | from_yaml | sort | first != inventory_hostname"
+
+    - name: Create /root/generate dir
+      ansible.builtin.file:
+        path: /root/generate
+        owner: root
+        group: root
+        mode: 0700
+        state: directory
+
+    - name: Generate mon keyring (control node stat)
       delegate_to: 127.0.0.1
-      shell:
-        cmd: ceph-authtool --create-keyring {{ task_mon_keyring }} --gen-key -n mon. --cap mon 'allow *'
-        creates: '{{ task_mon_keyring }}'
+      ansible.builtin.stat:
+        path: '{{ task_mon_keyring }}'
+      register: task_mon_keyring_stat
+
+    - name: Generate mon keyring (copy to remote)
+      ansible.builtin.copy:
+        src: '{{ task_mon_keyring }}'
+        dest: /root/generate/task_mon_keyring
+      when: task_mon_keyring_stat.stat.exists
+
+    - name: Generate mon keyring
+      ansible.builtin.shell:
+        cmd: ceph-authtool --create-keyring /root/generate/task_mon_keyring --gen-key -n mon. --cap mon 'allow *'
+        creates: /root/generate/task_mon_keyring
       throttle: 1
       when: 'task_fsid'
 
-    - name: Generate client.admin keyring
+    - name: Generate mon keyring (fetch back to control node)
+      ansible.builtin.fetch:
+        src: /root/generate/task_mon_keyring
+        dest: '{{ task_mon_keyring }}'
+        flat: true
+      when: not task_mon_keyring_stat.stat.exists
+
+    - name: Generate client.admin keyring (control node stat)
       delegate_to: 127.0.0.1
-      shell:
-        cmd: ceph-authtool --create-keyring {{ task_client_admin_keyring }} --gen-key -n client.admin --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *' --cap mgr 'allow *'
-        creates: '{{ task_client_admin_keyring }}'
+      ansible.builtin.stat:
+        path: '{{ task_client_admin_keyring }}'
+      register: task_client_admin_keyring_stat
+
+    - name: Generate client.admin keyring (copy to remote)
+      ansible.builtin.copy:
+        src: '{{ task_client_admin_keyring }}'
+        dest: /root/generate/task_client_admin_keyring
+      when: task_client_admin_keyring_stat.stat.exists
+
+    - name: Generate client.admin keyring
+      ansible.builtin.shell:
+        cmd: ceph-authtool --create-keyring /root/generate/task_client_admin_keyring --gen-key -n client.admin --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *' --cap mgr 'allow *'
+        creates: /root/generate/task_client_admin_keyring
       throttle: 1
       notify: Add key to client.admin keyring
       when: 'task_fsid'
 
-    - name: Generate bootstrap-osd keyring
+    - name: Generate client.admin keyring (fetch back to control node)
+      ansible.builtin.fetch:
+        src: /root/generate/task_client_admin_keyring
+        dest: '{{ task_client_admin_keyring }}'
+        flat: true
+      when: not task_client_admin_keyring_stat.stat.exists
+
+    - name: Generate bootstrap-osd keyring (control node stat)
       delegate_to: 127.0.0.1
-      shell:
-        cmd: ceph-authtool --create-keyring {{ task_bootstrap_osd_keyring }} --gen-key -n client.bootstrap-osd --cap mon 'profile bootstrap-osd' --cap mgr 'allow r'
-        creates: '{{ task_bootstrap_osd_keyring }}'
+      ansible.builtin.stat:
+        path: '{{ task_bootstrap_osd_keyring }}'
+      register: task_bootstrap_osd_keyring_stat
+
+    - name: Generate bootstrap-osd keyring (copy to remote)
+      ansible.builtin.copy:
+        src: '{{ task_bootstrap_osd_keyring }}'
+        dest: /root/generate/task_bootstrap_osd_keyring
+      when: task_bootstrap_osd_keyring_stat.stat.exists
+
+    - name: Generate bootstrap-osd keyring
+      ansible.builtin.shell:
+        cmd: ceph-authtool --create-keyring /root/generate/task_bootstrap_osd_keyring --gen-key -n client.bootstrap-osd --cap mon 'profile bootstrap-osd' --cap mgr 'allow r'
+        creates: /root/generate/task_bootstrap_osd_keyring
       throttle: 1
       notify: Add key to bootstrap-osd keyring
       when: 'task_fsid'
 
-    - name: Generate mon map
+    - name: Generate bootstrap-osd keyring (fetch back to control node)
+      ansible.builtin.fetch:
+        src: /root/generate/task_bootstrap_osd_keyring
+        dest: '{{ task_bootstrap_osd_keyring }}'
+        flat: true
+      when: not task_bootstrap_osd_keyring_stat.stat.exists
+
+    - name: Generate mon map (control node stat)
       delegate_to: 127.0.0.1
-      shell:
-        cmd: monmaptool --create{% if task_release_majors[task_release] | default(None) %} --set-min-mon-release={{ task_release_majors[task_release] }}{% endif %} --fsid {{ task_fsid }} {{ task_mon_map }}
-        creates: '{{ task_mon_map }}'
+      ansible.builtin.stat:
+        path: '{{ task_mon_map }}'
+      register: task_mon_map_stat
+
+    - name: Generate mon map (copy to remote)
+      ansible.builtin.copy:
+        src: '{{ task_mon_map }}'
+        dest: /root/generate/task_mon_map
+      when: task_mon_map_stat.stat.exists
+
+    - name: Generate mon map
+      ansible.builtin.shell:
+        cmd: monmaptool --create{% if task_release_majors[task_release] | default(None) %} --set-min-mon-release={{ task_release_majors[task_release] }}{% endif %} --fsid {{ task_fsid }} /root/generate/task_mon_map
+        creates: /root/generate/task_mon_map
       throttle: 1
       notify: Add nodes to mon map
       when: 'task_fsid'
 
+    - name: Generate mon map (fetch back to control node)
+      ansible.builtin.fetch:
+        src: /root/generate/task_mon_map
+        dest: '{{ task_mon_map }}'
+        flat: true
+      when: not task_mon_map_stat.stat.exists
+
   handlers:
-    - name: Add key to client.admin keyring
-      delegate_to: 127.0.0.1
-      shell:
-        cmd: ceph-authtool {{ task_mon_keyring }} --import-keyring {{ task_client_admin_keyring }}
+    - name: Add key to client.admin keyring (remote)
+      ansible.builtin.shell:
+        cmd: ceph-authtool /root/generate/task_mon_keyring --import-keyring /root/generate/task_client_admin_keyring
+      listen: Add key to client.admin keyring
 
-    - name: Add key to bootstrap-osd keyring
-      delegate_to: 127.0.0.1
-      shell:
-        cmd: ceph-authtool {{ task_mon_keyring }} --import-keyring {{ task_bootstrap_osd_keyring }}
+    - name: Add key to client.admin keyring (fetch)
+      ansible.builtin.fetch:
+        src: /root/generate/task_mon_keyring
+        dest: '{{ task_mon_keyring }}'
+        flat: true
+      listen: Add key to client.admin keyring
 
-    - name: Add nodes to mon map
-      delegate_to: 127.0.0.1
-      shell:
-        cmd: monmaptool --add {{ item.name }} {{ item.ip }} {{ task_mon_map }}
+    - name: Add key to bootstrap-osd keyring (remote)
+      ansible.builtin.shell:
+        cmd: ceph-authtool /root/generate/task_mon_keyring --import-keyring /root/generate/task_bootstrap_osd_keyring
+      listen: Add key to bootstrap-osd keyring
+
+    - name: Add key to bootstrap-osd keyring (fetch)
+      ansible.builtin.fetch:
+        src: /root/generate/task_mon_keyring
+        dest: '{{ task_mon_keyring }}'
+        flat: true
+      listen: Add key to bootstrap-osd keyring
+
+    - name: Add nodes to mon map (remote)
+      ansible.builtin.shell:
+        cmd: monmaptool --add {{ item.name }} {{ item.ip }} /root/generate/task_mon_map
       loop: "{{ lookup('template', '../files/ceph/ceph.monitors.tpl') | from_yaml | default([]) }}"
+      listen: Add nodes to mon map
+
+    - name: Add nodes to mon map (fetch)
+      ansible.builtin.fetch:
+        src: /root/generate/task_mon_map
+        dest: '{{ task_mon_map }}'
+        flat: true
+      listen: Add nodes to mon map
 
 - name: Ceph - Set up config and keyrings
   hosts: all

--- a/ansible/books/lvmcluster.yaml
+++ b/ansible/books/lvmcluster.yaml
@@ -76,6 +76,13 @@
         state: started
       when: 'task_name'
 
+    - name: Enable the wdmd unit
+      systemd:
+        enabled: yes
+        name: wdmd
+        state: started
+      when: 'task_name'
+
 - name: LVM Cluster - Create VGs
   hosts: all
   order: shuffle


### PR DESCRIPTION
I want to allow this project to target an Incus host, such as a remote host, that is not expected to be on the localhost of the system I'm running the commands from.

Allow Terraform/OpenTofu to target remote host
- creation of variables to use and defaults that can easily be overridden
- removal of hard coded values in modules to allow for variable overrides for hosts that need different values
- separation of incus provider into it's own file where connection details are specified
- .opentofu-version file of version tested/used that can be automatically loaded with tenv
- updated README with additional guidance for getting started

Allow Ansible to run commands on  remote host
- ceph packages were not found for `noble` (ubuntu/24.04) at the https://download.ceph.com/debian-reef/dists/ repo so I changed the `dev-incus-deploy` cluster in `main.tf` to use the newest version supported by the ceph distribution `jammy` (ubuntu/22.04).
- modified `ceph.yaml` playbook to run "Ceph - Generate cluster keys and maps" plays after installing ceph packages on hosts. The play also now only runs the play against the server01 host. This avoids delegating and running ceph commands on the control node (localhost/127.0.0.1) and uses the specified installed version of ceph tools to execute commands on one of the remote hosts instead. To maintain the same functionality additional tasks were added to first check for existing files on the control node (control node stat), copy it to the remote (copy to remote) if one exists to avoid generating a new file, and (fetch back to control node) if the file doesn't exist on the control node already like in the case of generating it for the first time on the remote host.
- modified `ceph.monitors.tpl` to use all groups instead of the hosts in the play because the play was now only run on server01 instead of running on all hots and delegating to execute commands on the control node. This primarily impacts the "Add nodes to mon map" task.
- additional guidance including `Pipfile` and `ansible_requirements.yml` for reference to a known working version of ansible and collections that can be used to run the playbooks in addition to some reference commands in `README.md` for installing and executing the same version of Ansible and dependencies specified in the additional Pipfile.
- added some examples to `README.md` for launching instances on a new cluster