### PR TITLE
github: Reduce CPU allocation to 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
           - ubuntu/24.04
     runs-on:
       - self-hosted
-      - cpu-16
+      - cpu-12
       - mem-32G
       - disk-100G
       - arch-amd64


### PR DESCRIPTION
Most of the test runners run on 24c/48t EPYC with 6c/12t per NUMA node, so reducing the CPU from 16 cores down to 12 should provide better performance.