### PR TITLE
Introduce and rely on the nvme role for the nvme play

### DIFF
--- a/ansible/books/nvme.yaml
+++ b/ansible/books/nvme.yaml
@@ -1,33 +1,11 @@
 ---
 - name: NVME - Install packages and host config
   hosts: all
+  collections:
+    - lxc.incus
   order: shuffle
   gather_facts: yes
   gather_subset:
     - "distribution_release"
-  vars:
-    task_targets: "{{ nvme_targets | default([]) }}"
-  any_errors_fatal: true
-  tasks:
-    - name: Install the NVME packages
-      ansible.builtin.package:
-        name:
-          - nvme-cli
-        state: present
-      when: 'task_targets | length > 0'
-
-    - name: Configure NVME discovery
-      template:
-        src: ../files/nvme/discovery.conf.tpl
-        dest: /etc/nvme/discovery.conf
-      when: 'task_targets | length > 0'
-      notify:
-       - Discover NVME targets
-       - Connect NVME targets
-
-  handlers:
-    - name: Discover NVME targets
-      shell: nvme discover
-
-    - name: Connect NVME targets
-      shell: nvme connect-all
+  roles:
+    - role: nvme

--- a/roles/nvme/README.md
+++ b/roles/nvme/README.md
@@ -1,0 +1,4 @@
+nvme
+====
+
+Install tools for NVME

--- a/roles/nvme/defaults/main.yml
+++ b/roles/nvme/defaults/main.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+nvme_targets: []

--- a/roles/nvme/handlers/main.yml
+++ b/roles/nvme/handlers/main.yml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: Discover NVME targets
+  ansible.builtin.command: nvme discover
+  changed_when: true
+
+- name: Connect NVME targets
+  ansible.builtin.command: nvme connect-all
+  changed_when: true

--- a/roles/nvme/meta/main.yml
+++ b/roles/nvme/meta/main.yml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+galaxy_info:
+  author: Stéphane Graber
+  description: role to create install the NVME tools
+  company: Zabbly
+  license: Apache-2.0
+  min_ansible_version: "2.14"
+  galaxy_tags:
+    - incus
+    - nvme
+dependencies: []

--- a/roles/nvme/tasks/main.yml
+++ b/roles/nvme/tasks/main.yml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: Install the NVME packages
+  ansible.builtin.package:
+    name:
+      - nvme-cli
+    state: present
+  when: 'nvme_targets | length > 0'
+
+- name: Configure NVME discovery
+  ansible.builtin.template:
+    src: discovery.conf.j2
+    dest: /etc/nvme/discovery.conf
+    mode: "0644"
+  when: 'nvme_targets | length > 0'
+  notify:
+    - Discover NVME targets
+    - Connect NVME targets

--- a/roles/nvme/templates/discovery.conf.j2
+++ b/roles/nvme/templates/discovery.conf.j2
@@ -4,6 +4,6 @@
 #
 # Example:
 # --transport=<trtype> --traddr=<traddr> --trsvcid=<trsvcid> --host-traddr=<host-traddr> --host-iface=<host-iface>
-{% for target in task_targets %}
+{% for target in nvme_targets %}
 --transport=tcp --traddr={{ target }}
 {% endfor %}


### PR DESCRIPTION
changes include:
- scaffold the nvme role directory with meta
- copy code and vars to the role
- add the template file to the role
- align with the linter
- update the playbook to rely on the role
- remove unused files from the ansible directory