### PR TITLE
Introduce the netplan role and rely on it for the matching play

### DIFF
--- a/ansible/books/netplan.yaml
+++ b/ansible/books/netplan.yaml
@@ -1,47 +1,12 @@
 ---
 - name: Netplan - Override system configuration
   hosts: all
+  collections:
+    - lxc.incus
   order: shuffle
   gather_facts: yes
   gather_subset:
     - "distribution_release"
   any_errors_fatal: true
-  tasks:
-    - name: Check if distribution is supported
-      meta: end_play
-      when: 'ansible_distribution not in ("Ubuntu", "Debian")'
-
-    - name: Check if a Netplan configuration exists
-      local_action: stat path=../data/netplan/{{ inventory_hostname }}.yaml
-      register: main_file
-
-    - name: Ensure netplan is installed
-      apt:
-        name:
-          - netplan.io
-        state: present
-      when: main_file.stat.exists
-
-    - name: Remove existing configuration
-      file:
-        path: "/etc/netplan/{{ item }}"
-        state: absent
-      loop:
-        - 00-snapd-config.yaml
-        - 00-installer-config.yaml
-        - 10-lxc.yaml
-        - 50-cloud-init.yaml
-      when: main_file.stat.exists
-      notify: Apply netplan
-
-    - name: Transfer netplan configuration
-      copy:
-        src: ../data/netplan/{{ inventory_hostname }}.yaml
-        dest: /etc/netplan/00-ansible-main.yaml
-        mode: 0600
-      when: main_file.stat.exists
-      notify: Apply netplan
-
-  handlers:
-    - name: Apply netplan
-      shell: netplan apply
+  roles:
+    - role: netplan

--- a/roles/netplan/README.md
+++ b/roles/netplan/README.md
@@ -1,0 +1,4 @@
+natplan
+=======
+
+Apply a netplan configuration to the target.

--- a/roles/netplan/handlers/main.yml
+++ b/roles/netplan/handlers/main.yml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: Ensure netplan is installed
+  ansible.builtin.apt:
+    name:
+      - netplan.io
+    state: present
+
+- name: Remove existing configuration
+  ansible.builtin.file:
+    path: "/etc/netplan/{{ item }}"
+    state: absent
+  loop:
+    - 00-snapd-config.yaml
+    - 00-installer-config.yaml
+    - 10-lxc.yaml
+    - 50-cloud-init.yaml
+  notify: Apply netplan
+
+- name: Transfer netplan configuration
+  ansible.builtin.copy:
+    src: ../data/netplan/{{ inventory_hostname }}.yaml
+    dest: /etc/netplan/00-ansible-main.yaml
+    mode: "0600"
+  notify: Apply netplan
+
+- name: Apply netplan
+  ansible.builtin.command: netplan apply
+  changed_when: true

--- a/roles/netplan/meta/main.yml
+++ b/roles/netplan/meta/main.yml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+galaxy_info:
+  author: Stéphane Graber
+  description: role to apply a netplan configuration
+  company: Zabbly
+  license: Apache-2.0
+  min_ansible_version: "2.14"
+  galaxy_tags:
+    - incus
+    - netplan
+dependencies: []

--- a/roles/netplan/tasks/main.yml
+++ b/roles/netplan/tasks/main.yml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: Check if distribution is supported
+  ansible.builtin.meta: end_play
+  when: 'ansible_distribution not in ("Ubuntu", "Debian")'
+
+- name: Check if a Netplan configuration exists
+  delegate_to: localhost
+  ansible.builtin.stat:
+    path: ../data/netplan/{{ inventory_hostname }}.yaml
+  register: main_file
+  notify:
+    - Ensure netplan is installed
+    - Remove existing configuration
+    - Transfer netplan configuration
+  changed_when: main_file.stat.exists


### PR DESCRIPTION
changes include:
- scaffold the netplan role directory with meta
- copy code and vars to the role
- align with the linter
- update the playbook to rely on the role