### PR TITLE
role for recommended system settings

### DIFF
--- a/ansible/books/system_settings.yaml
+++ b/ansible/books/system_settings.yaml
@@ -1,0 +1,10 @@
+---
+- name: Incus - recommended system settings
+  collections:
+    - lxc.incus
+  hosts: all
+  order: shuffle
+  gather_facts: yes
+  any_errors_fatal: true
+  roles:
+    - role: system_settings

--- a/ansible/deploy.yaml
+++ b/ansible/deploy.yaml
@@ -1,4 +1,5 @@
 - import_playbook: books/local.early.yaml
+- import_playbook: books/system_settings.yaml
 - import_playbook: books/netplan.yaml
 - import_playbook: books/environment.yaml
 - import_playbook: books/nvme.yaml

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,6 +13,7 @@ tags: ["lxc", "incus"]
 dependencies:
   community.general: ">=10.4.0"
   community.crypto: ">=2.20.0"
+  ansible.posix: ">=1.6.0"
 repository: https://github.com/lxc/incus-deploy
 documentation: https://github.com/lxc/incus-deploy
 homepage: https://github.com/lxc/incus-deploy

--- a/roles/system_settings/README.md
+++ b/roles/system_settings/README.md
@@ -1,0 +1,4 @@
+system_settings
+===============
+
+Set appropriate system settings for Incus

--- a/roles/system_settings/meta/main.yml
+++ b/roles/system_settings/meta/main.yml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+galaxy_info:
+  author: Stéphane Graber
+  description: role to set the recommanded system settings
+  company: Zabbly
+  license: Apache-2.0
+  min_ansible_version: "2.14"
+  galaxy_tags:
+    - incus
+    - system
+dependencies: []

--- a/roles/system_settings/tasks/main.yml
+++ b/roles/system_settings/tasks/main.yml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: Incus set sysctl
+  ansible.posix.sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    state: present
+  loop:
+    - { name: "fs.aio-max-nr", value: "524288"}
+    - { name: "fs.inotify.max_queued_events", value: "1048576"}
+    - { name: "fs.inotify.max_user_instances", value: "1048576"}
+    - { name: "fs.inotify.max_user_watches", value: "1048576"}
+    - { name: "kernel.keys.maxbytes", value: "2000000"}
+    - { name: "kernel.keys.maxkeys", value: "2000"}
+    - { name: "net.core.bpf_jit_limit", value: "1000000000"}
+    - { name: "net.ipv4.neigh.default.gc_thresh3", value: "8192"}
+    - { name: "net.ipv6.neigh.default.gc_thresh3", value: "8192"}
+    - { name: "vm.max_map_count", value: "262144"}
+
+- name: Incus PAM limits
+  community.general.pam_limits:
+    domain: "{{ item.domain }}"
+    limit_type: "{{ item.limit_type }}"
+    limit_item: "{{ item.limit_item }}"
+    value: "{{ item.value }}"
+  loop:
+    - { domain: "*", limit_type: "soft", limit_item: "nofile", value: "1048576"}
+    - { domain: "*", limit_type: "hard", limit_item: "nofile", value: "1048576"}
+    - { domain: "root", limit_type: "soft", limit_item: "nofile", value: "1048576"}
+    - { domain: "root", limit_type: "hard", limit_item: "nofile", value: "1048576"}
+    - { domain: "*", limit_type: "soft", limit_item: "memlock", value: "unlimited"}
+    - { domain: "*", limit_type: "hard", limit_item: "memlock", value: "unlimited"}
+    - { domain: "root", limit_type: "soft", limit_item: "memlock", value: "unlimited"}
+    - { domain: "root", limit_type: "hard", limit_item: "memlock", value: "unlimited"}


### PR DESCRIPTION
add a role named `system_settings` to the lxc.incus collection that implements the recommended parameters as described in [Incus Server > System Settings](https://linuxcontainers.org/incus/docs/main/reference/server_settings/) documentation

> Note: The error on the debian/12 is a transient error