### PR TITLE
skip don't stop on unsupported or unconfigured role

### DIFF
--- a/roles/ceph/tasks/main.yml
+++ b/roles/ceph/tasks/main.yml
@@ -14,40 +14,46 @@
 - name: Install packages
   ansible.builtin.import_tasks: packages.yml
 
-- name: Check if part of Ceph
-  ansible.builtin.meta: end_host
-  when: "not ceph_fsid"
-
 - name: Create cluster keys
   ansible.builtin.import_tasks: create_keys.yml
-  when: "lookup('template', 'ceph.monitors.names.j2') | from_yaml | sort | first == inventory_hostname"
+  when: "ceph_fsid and lookup('template', 'ceph.monitors.names.j2') | from_yaml | sort | first == inventory_hostname"
 
 - name: Force handler execution
   ansible.builtin.meta: flush_handlers
+  when: "ceph_fsid"
 
 - name: Deploy cluster keys
   ansible.builtin.import_tasks: deploy_keys.yml
+  when: "ceph_fsid"
 
 - name: Force handler execution
   ansible.builtin.meta: flush_handlers
+  when: "ceph_fsid"
 
 - name: Configure ceph mon
   ansible.builtin.import_tasks: mon.yml
+  when: "ceph_fsid"
 
 - name: Force handler execution
   ansible.builtin.meta: flush_handlers
+  when: "ceph_fsid"
 
 - name: Configure ceph osd
   ansible.builtin.import_tasks: osd.yml
+  when: "ceph_fsid"
 
 - name: Configure ceph mgr
   ansible.builtin.import_tasks: mgr.yml
+  when: "ceph_fsid"
 
 - name: Configure ceph mds
   ansible.builtin.import_tasks: mds.yml
+  when: "ceph_fsid"
 
 - name: Configure ceph rgw
   ansible.builtin.import_tasks: rgw.yml
+  when: "ceph_fsid"
 
 - name: Configure ceph rbd-mirror
   ansible.builtin.import_tasks: rdb_mirror.yml
+  when: "ceph_fsid"

--- a/roles/incus/tasks/main.yml
+++ b/roles/incus/tasks/main.yml
@@ -1,14 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-- name: Check if distribution is supported
-  ansible.builtin.meta: end_play
-  when: 'ansible_distribution not in ("Ubuntu", "Debian", "CentOS")'
-
 - name: Add the Debian repository registration
   ansible.builtin.import_tasks: "repo_deb.yml"
+  when: 'ansible_distribution in ("Ubuntu", "Debian")'
 
 - name: Add the CentOS repository registration
   ansible.builtin.import_tasks: repo_dnf.yml
+  when: 'ansible_distribution == "CentOS"'
 
 - name: Run the package and configuration for Incus
   ansible.builtin.import_tasks: installation.yml
+  when: 'ansible_distribution in ("Ubuntu", "Debian", "CentOS")'

--- a/roles/linstor/tasks/main.yml
+++ b/roles/linstor/tasks/main.yml
@@ -2,18 +2,24 @@
 ---
 - name: Add the Debian repository registration
   ansible.builtin.import_tasks: repo_deb.yml
+  when: 'ansible_distribution == "Ubuntu" and ansible_distribution_release != "focal"'
 
 - name: Flush the handlers
   ansible.builtin.meta: flush_handlers
+  when: 'ansible_distribution == "Ubuntu" and ansible_distribution_release != "focal"'
 
 - name: Install the package for Linstor
   ansible.builtin.import_tasks: installation.yml
+  when: 'ansible_distribution == "Ubuntu" and ansible_distribution_release != "focal"'
 
 - name: Enable Linstor Services
   ansible.builtin.import_tasks: services.yml
+  when: 'ansible_distribution == "Ubuntu" and ansible_distribution_release != "focal"'
 
 - name: Create Linstor Satellite
   ansible.builtin.import_tasks: satellite.yml
+  when: 'ansible_distribution == "Ubuntu" and ansible_distribution_release != "focal"'
 
 - name: Create storage pool and add the disks
   ansible.builtin.import_tasks: storage.yml
+  when: 'ansible_distribution == "Ubuntu" and ansible_distribution_release != "focal"'

--- a/roles/linstor/tasks/repo_deb.yml
+++ b/roles/linstor/tasks/repo_deb.yml
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-- name: Check if distribution is supported
-  ansible.builtin.meta: end_play
-  when: 'ansible_distribution != "Ubuntu" or ansible_distribution_release == "focal"'
-
 - name: Create apt keyring path
   ansible.builtin.file:
     path: /etc/apt/keyrings/

--- a/roles/netplan/tasks/main.yml
+++ b/roles/netplan/tasks/main.yml
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-- name: Check if distribution is supported
-  ansible.builtin.meta: end_play
-  when: 'ansible_distribution not in ("Ubuntu", "Debian")'
-
 - name: Check if a Netplan configuration exists
   delegate_to: localhost
   ansible.builtin.stat:
@@ -14,3 +10,4 @@
     - Remove existing configuration
     - Transfer netplan configuration
   changed_when: main_file.stat.exists
+  when: 'ansible_distribution not in ("Ubuntu", "Debian")'

--- a/roles/ovn/tasks/configuration.yml
+++ b/roles/ovn/tasks/configuration.yml
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-- name: Check if distribution is supported
-  ansible.builtin.meta: end_play
-  when: 'ansible_distribution not in ("Ubuntu", "Debian")'
-
 - name: Create OVN config directory
   ansible.builtin.file:
     path: /etc/ovn

--- a/roles/ovn/tasks/main.yml
+++ b/roles/ovn/tasks/main.yml
@@ -1,22 +1,29 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-- name: Add keys and dertificates generation tasks
+- name: Add keys and certificates generation tasks
   ansible.builtin.import_tasks: certificates.yml
+  when: ansible_distribution in ("Ubuntu", "Debian")
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
+  when: ansible_distribution in ("Ubuntu", "Debian")
 
 - name: Register the Debian repository
   ansible.builtin.import_tasks: "repo_deb.yml"
+  when: ansible_distribution in ("Ubuntu", "Debian")
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
+  when: ansible_distribution in ("Ubuntu", "Debian")
 
 - name: Install packages
   ansible.builtin.import_tasks: "packages.yml"
+  when: ansible_distribution in ("Ubuntu", "Debian")
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
+  when: ansible_distribution in ("Ubuntu", "Debian")
 
 - name: Configure daemons
   ansible.builtin.import_tasks: "configuration.yml"
+  when: ansible_distribution in ("Ubuntu", "Debian")

--- a/roles/ovn/tasks/packages.yml
+++ b/roles/ovn/tasks/packages.yml
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-- name: Check if distribution is supported
-  ansible.builtin.meta: end_play
-  when: 'ansible_distribution not in ("Ubuntu", "Debian")'
-
 - name: Install the OVN central package
   ansible.builtin.apt:
     name:

--- a/roles/ovn/tasks/repo_deb.yml
+++ b/roles/ovn/tasks/repo_deb.yml
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-- name: Check if distribution is supported
-  ansible.builtin.meta: end_play
-  when: 'ansible_distribution not in ("Ubuntu", "Debian")'
-
 - name: Create apt keyring path
   ansible.builtin.file:
     path: /etc/apt/keyrings/


### PR DESCRIPTION
WIth the change from playbooks to roles we should not use `end_host` or `end_play` anymore. That is because this would stop the remaining of the playbook even when what we really want to do is actually skip the configuration for a role.

1. The easiest way to go would have been to replace those with `end_role`. Because of the configuration, the version of ansible we are using is not 2.18 yet so we cannot access this.

2. I am not convinced we should use a role for a version that does not apply. For instance, I would not have applied linstor to ubuntu 20.04 or Debian. However, currently the setup is the same for all those servers and I do not want to change the tests for now at least

3. The solution I propose is just to skip the sections after the test with a change to the `when` clause of the import that would have followed the `end_xxx`.

This PR is a requirement for #47 