### PR TITLE
register config in host facts and query facts

### DIFF
--- a/roles/ceph/tasks/main.yml
+++ b/roles/ceph/tasks/main.yml
@@ -1,5 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
+- name: Set facts from variables for cross host queries
+  ansible.builtin.set_fact:
+    cacheable: true
+    ceph_fsid: "{{ ceph_fsid }}"
+    ceph_roles: "{{ ceph_roles }}"
+
+- name: Set facts ceph_ip_address from variables if exists
+  ansible.builtin.set_fact:
+    cacheable: true
+    ceph_ip_address: "{{ ceph_ip_address }}"
+  when: "ceph_ip_address is defined"
+
 - name: Install debian repository
   ansible.builtin.import_tasks: repo_deb.yml
   when: 'ansible_distribution in ("Ubuntu", "Debian")'

--- a/roles/ceph/templates/ceph.monitors.j2
+++ b/roles/ceph/templates/ceph.monitors.j2
@@ -1,6 +1,6 @@
-{% for host in groups['all'] %}
-{% if hostvars[host]['ceph_fsid'] == ceph_fsid and "mon" in hostvars[host]['ceph_roles'] %}
+{% for host in vars['ansible_play_hosts'] | sort %}
+{% if hostvars[host]['ansible_facts']['ceph_fsid'] == ceph_fsid and "mon" in hostvars[host]['ansible_facts']['ceph_roles'] %}
 - name: "{{ host }}"
-  ip: "{{ hostvars[host]['ceph_ip_address'] | default(hostvars[host]['ansible_default_ipv6']['address'] | default(hostvars[host]['ansible_default_ipv4']['address'])) }}"
+  ip: "{{ hostvars[host]['ansible_facts']['ceph_ip_address'] | default(hostvars[host]['ansible_default_ipv6']['address'] | default(hostvars[host]['ansible_default_ipv4']['address'])) }}"
 {% endif %}
 {% endfor %}

--- a/roles/ceph/templates/ceph.monitors.names.j2
+++ b/roles/ceph/templates/ceph.monitors.names.j2
@@ -1,6 +1,6 @@
 {%- set found = namespace(count=0) %}
-{%- for host in vars['ansible_play_hosts'] %}
-{% if 'ceph_fsid' in hostvars[host] and hostvars[host]['ceph_fsid'] == ceph_fsid and 'ceph_roles' in hostvars[host] and "mon" in hostvars[host]['ceph_roles'] %}
+{%- for host in vars['ansible_play_hosts'] | sort %}
+{% if 'ceph_fsid' in hostvars[host]['ansible_facts'] and hostvars[host]['ansible_facts']['ceph_fsid'] == ceph_fsid and 'ceph_roles' in hostvars[host]['ansible_facts'] and "mon" in hostvars[host]['ansible_facts']['ceph_roles'] %}
 {% set found.count = found.count + 1 %}
 - "{{ host }}"
 {% endif %}

--- a/roles/incus/templates/ovn-central.servers.j2
+++ b/roles/incus/templates/ovn-central.servers.j2
@@ -1,5 +1,5 @@
 {% for host in vars['ansible_play_hosts'] | sort %}
-{% if hostvars[host]['ovn_name'] | default('') == ovn_name | default('') and hostvars[host]['ovn_az_name'] | default('') == ovn_az_name | default('') and "central" in hostvars[host]['ovn_roles'] | default([]) %}
-- "{{ hostvars[host]['ovn_ip_address'] | default(hostvars[host]['ansible_default_ipv6']['address'] | default(hostvars[host]['ansible_default_ipv4']['address'])) }}"
+{% if hostvars[host]['ansible_facts']['ovn_name'] | default('') == ovn_name | default('') and hostvars[host]['ansible_facts']['ovn_az_name'] | default('') == ovn_az_name | default('') and "central" in hostvars[host]['ansible_facts']['ovn_roles'] | default([]) %}
+- "{{ hostvars[host]['ansible_facts']['ovn_ip_address'] | default(hostvars[host]['ansible_default_ipv6']['address'] | default(hostvars[host]['ansible_default_ipv4']['address'])) }}"
 {% endif %}
 {% endfor %}

--- a/roles/linstor/tasks/main.yml
+++ b/roles/linstor/tasks/main.yml
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
+- name: Gather all satellite hosts
+  ansible.builtin.set_fact:
+    cacheable: true
+    linstor_roles: "{{ linstor_roles }}"
+
 - name: Add the Debian repository registration
   ansible.builtin.import_tasks: repo_deb.yml
   when: 'ansible_distribution == "Ubuntu" and ansible_distribution_release != "focal"'

--- a/roles/linstor/tasks/satellite.yml
+++ b/roles/linstor/tasks/satellite.yml
@@ -15,6 +15,6 @@
     {{ hostvars[item].ansible_facts.default_ipv6.address | default(hostvars[item].ansible_facts.default_ipv4.address) }}
     --node-type satellite
   register: create_node_output
-  loop: "{{ groups['all'] }}"
-  when: '("controller" in linstor_roles) and ("satellite" in hostvars[item]["linstor_roles"]) and (item not in existing_satellite_nodes)'
+  loop: "{{ ansible_play_hosts }}"
+  when: '("controller" in linstor_roles) and ("satellite" in hostvars[item]["ansible_facts"]["linstor_roles"]) and (item not in existing_satellite_nodes)'
   changed_when: "create_node_output.rc == 0"

--- a/roles/linstor/tasks/storage.yml
+++ b/roles/linstor/tasks/storage.yml
@@ -1,14 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
-- name: Gather all satellite hosts
+- name: Register all satellite hosts for every host
   ansible.builtin.set_fact:
-    satellite_hosts: >-
-      {{ groups['all']
-          | map('extract', hostvars)
-          | selectattr('linstor_roles', 'defined')
-          | selectattr('linstor_roles', 'contains', 'satellite')
-          | map(attribute='inventory_hostname')
-          | list }}
+    yaml_satellite_hosts: |-
+      {% for playhost in ansible_play_hosts %}
+      {% if 'satellite' in hostvars[playhost]['ansible_facts']['linstor_roles'] %}
+        - "{{ playhost }}"
+      {% endif %}
+      {% endfor %}
 
 - name: List storage pools
   ansible.builtin.command: linstor --machine-readable storage-pool list
@@ -20,7 +19,7 @@
   ansible.builtin.set_fact:
     satellites_without_storage_pools: >-
       {{
-        satellite_hosts | difference(
+        yaml_satellite_hosts | from_yaml | difference(
           storage_pool_output.stdout | from_json | json_query('[0][?provider_kind!=`DISKLESS`].node_name') | unique
         )
       }}
@@ -33,6 +32,6 @@
     --pool-name linstor-{{ linstor_pool_name }} {{ linstor_pool_driver }} {{ item }}
     {{ linstor_mapped_disks | join(' ') }}
   register: create_storage_pool_output
-  loop: "{{ groups['all'] }}"
-  when: '("controller" in linstor_roles) and ("satellite" in hostvars[item]["linstor_roles"]) and (item in satellites_without_storage_pools)'
+  loop: "{{ ansible_play_hosts }}"
+  when: '("controller" in linstor_roles) and ("satellite" in hostvars[item]["ansible_facts"]["linstor_roles"]) and (item in satellites_without_storage_pools)'
   changed_when: "create_storage_pool_output.rc == 0"

--- a/roles/ovn/tasks/main.yml
+++ b/roles/ovn/tasks/main.yml
@@ -1,5 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
+- name: Set facts from variables for cross host queries
+  ansible.builtin.set_fact:
+    cacheable: true
+    ovn_name: "{{ ovn_name }}"
+    ovn_az_name: "{{ ovn_az_name }}"
+    ovn_roles: "{{ ovn_roles }}"
+
+- name: Set ovn_ip_address fact from variable if exists
+  ansible.builtin.set_fact:
+    cacheable: true
+    ovn_ip_address: "{{ ovn_ip_address }}"
+  when: "ovn_ip_address is defined"
+
 - name: Add keys and certificates generation tasks
   ansible.builtin.import_tasks: certificates.yml
   when: ansible_distribution in ("Ubuntu", "Debian")

--- a/roles/ovn/templates/ovn-central.servers.j2
+++ b/roles/ovn/templates/ovn-central.servers.j2
@@ -1,5 +1,5 @@
 {% for host in vars['ansible_play_hosts'] | sort %}
-{% if hostvars[host]['ovn_name'] | default('') == ovn_name | default('') and hostvars[host]['ovn_az_name'] | default('') == ovn_az_name | default('') and "central" in hostvars[host]['ovn_roles'] | default([]) %}
-- "{{ hostvars[host]['ovn_ip_address'] | default(hostvars[host]['ansible_default_ipv6']['address'] | default(hostvars[host]['ansible_default_ipv4']['address'])) }}"
+{% if hostvars[host]['ansible_facts']['ovn_name'] | default('') == ovn_name | default('') and hostvars[host]['ansible_facts']['ovn_az_name'] | default('') == ovn_az_name | default('') and "central" in hostvars[host]['ansible_facts']['ovn_roles'] | default([]) %}
+- "{{ hostvars[host]['ansible_facts']['ovn_ip_address'] | default(hostvars[host]['ansible_default_ipv6']['address'] | default(hostvars[host]['ansible_default_ipv4']['address'])) }}"
 {% endif %}
 {% endfor %}

--- a/roles/ovn/templates/ovn-ic.servers.j2
+++ b/roles/ovn/templates/ovn-ic.servers.j2
@@ -1,5 +1,5 @@
 {% for host in vars['ansible_play_hosts'] | sort %}
-{% if hostvars[host]['ovn_name'] == ovn_name | default('') and "ic-db" in hostvars[host]['ovn_roles'] %}
-- "{{ hostvars[host]['ovn_ip_address'] | default(hostvars[host]['ansible_default_ipv6']['address'] | default(hostvars[host]['ansible_default_ipv4']['address'])) }}"
+{% if hostvars[host]['ansible_facts']['ovn_name'] == ovn_name | default('') and "ic-db" in hostvars[host]['ansible_facts']['ovn_roles'] %}
+- "{{ hostvars[host]['ansible_facts']['ovn_ip_address'] | default(hostvars[host]['ansible_default_ipv6']['address'] | default(hostvars[host]['ansible_default_ipv4']['address'])) }}"
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
This PR fixes #58. It modifies the roles so that variables can be set at the playbook level instead of the host inventory. In order to do that, it:
- registers variables with facts for every hosts with `cacheable=true` so that they can be queried later from facts and different hosts
- changes the access from `groups['all']` and/or `hostvars[host].value` to `ansible_play_hosts` and `hostvars[host]['ansible_facts'].value`
- rewrites the query to build satellite_hosts with a jinja2 syntax