### PR TITLE
fix linstor json query with right property

### DIFF
--- a/roles/linstor/tasks/storage.yml
+++ b/roles/linstor/tasks/storage.yml
@@ -21,7 +21,7 @@
     satellites_without_storage_pools: >-
       {{
         satellite_hosts | difference(
-          storage_pool_output.stdout | from_json | json_query('[0][?linstor_pool_driver!=`DISKLESS`].node_name') | unique
+          storage_pool_output.stdout | from_json | json_query('[0][?provider_kind!=`DISKLESS`].node_name') | unique
         )
       }}
   changed_when: false


### PR DESCRIPTION
fixes #55 . This bug has been introduced by me in #41 . This was due to a search and replace of `provider_kind` that was not properly checked. I have reviewed that PR and it looks like it is the only one. Unfortunately it did not break the tests. My apologies.