### PR TITLE
fix yaml linter, ansible linter and dist-upgrade issues

### DIFF
--- a/roles/incus/handlers/installation.yml
+++ b/roles/incus/handlers/installation.yml
@@ -1,5 +1,53 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
+- name: Wait 5s to avoid token use before valid
+  ansible.builtin.wait_for:
+    timeout: 5
+  delegate_to: localhost
+  changed_when: false
+
+- name: Join the cluster
+  throttle: 1
+  ansible.builtin.command:
+    cmd: "incus --force-local admin init --preseed"
+    stdin: |-
+      cluster:
+        enabled: true
+        cluster_address: "{{ incus_ip_address_or_default }}"
+        cluster_token: "{{ cluster_add.stdout }}"
+        server_address: "{{ incus_ip_address_or_default }}"
+        member_config:{%- for pool in incus_init.storage %}
+      {%- for key in incus_init.storage[pool].local_config | default([]) %}
+
+          - entity: storage-pool
+            name: {{ pool }}
+            key: {{ key }}
+            value: {{ incus_init.storage[pool].local_config[key] }}
+      {%- endfor %}
+      {%- endfor %}
+      {%- for network in incus_init.network %}
+      {%- for key in incus_init.network[network].local_config | default([]) %}
+
+          - entity: network
+            name: {{ network }}
+            key: {{ key }}
+            value: {{ incus_init.network[network].local_config[key] }}
+      {%- endfor %}
+      {%- endfor %}
+  changed_when: true
+
+- name: Apply additional configuration
+  ansible.builtin.command: "incus config set {{ item.key }}=\"{{ item.value }}\""
+  loop: "{{ incus_init['config'] | default({}) | dict2items }}"
+  changed_when: true
+
+- name: Load client certificates
+  ansible.builtin.command:
+    cmd: "incus config trust add-certificate --name \"{{ item.key }}\" --type={{ item.value.type | default('client') }} -"
+    stdin: "{{ item.value.certificate }}"
+  loop: "{{ incus_init['clients'] | default({}) | dict2items }}"
+  changed_when: true
+
 - name: Restart Incus
   ansible.builtin.systemd:
     name: incus.service

--- a/roles/incus/tasks/installation.yml
+++ b/roles/incus/tasks/installation.yml
@@ -98,6 +98,9 @@
   when: >-
     (install_deb.changed or install_rpm.changed) and
     ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname))
+  notify:
+    - "Apply additional configuration"
+    - "Load client certificates"
   changed_when: true
 
 - name: Set cluster listen address
@@ -109,16 +112,14 @@
   ansible.builtin.command: >-
     incus --force-local config
     set network.ovn.northbound_connection={{ incus_ovn_northbound }}
-    network.ovn.client_cert="{{ lookup('file', ovn_config_dir+'/'+inventory_hostname+'.crt') }}"
-    network.ovn.client_key="{{ lookup('file', ovn_config_dir+'/'+inventory_hostname+'.key') }}"
-    network.ovn.ca_cert="{{ lookup('file', ovn_config_dir+'/ca.crt') }}"
+    network.ovn.client_cert="{{ lookup('file', ovn_config_dir + '/' + inventory_hostname + '.crt') }}"
+    network.ovn.client_key="{{ lookup('file', ovn_config_dir + '/' + inventory_hostname + '.key') }}"
+    network.ovn.ca_cert="{{ lookup('file', ovn_config_dir + '/ca.crt') }}"
   notify: Restart Incus
   when: >-
     (install_deb.changed or install_rpm.changed) and
     incus_ovn_northbound and
     ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname))
-  tags:
-    - skip_ansible_lint
   changed_when: true
 
 - name: Add networks
@@ -178,25 +179,6 @@
     ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname))
   changed_when: true
 
-- name: Bootstrap the cluster
-  ansible.builtin.command: "incus --force-local cluster enable {{ inventory_hostname }}"
-  when: '(install_deb.changed or install_rpm.changed) and "cluster" in incus_roles and incus_servers[0] == inventory_hostname'
-  changed_when: true
-
-- name: Create join tokens
-  delegate_to: "{{ incus_servers[0] }}"
-  ansible.builtin.command: "incus --force-local --quiet cluster add {{ inventory_hostname }}"
-  register: cluster_add
-  when: '(install_deb.changed or install_rpm.changed) and "cluster" in incus_roles and incus_servers[0] != inventory_hostname'
-  changed_when: true
-
-- name: Wait 5s to avoid token use before valid
-  ansible.builtin.wait_for:
-    timeout: 5
-  delegate_to: localhost
-  when: '(install_deb.changed or install_rpm.changed) and "cluster" in incus_roles and incus_servers[0] != inventory_hostname'
-  changed_when: false
-
 - name: Set linstor controller_connection property
   ansible.builtin.command: >-
     incus --force-local config
@@ -209,54 +191,17 @@
     ansible_distribution_release != "focal"
   changed_when: "register_linstor_controller.rc == 0"
 
-- name: Join the cluster
-  throttle: 1
-  ansible.builtin.command:
-    cmd: "incus --force-local admin init --preseed"
-    stdin: |-
-      cluster:
-        enabled: true
-        cluster_address: "{{ incus_ip_address_or_default }}"
-        cluster_token: "{{ cluster_add.stdout }}"
-        server_address: "{{ incus_ip_address_or_default }}"
-        member_config:
-        {%- for pool in incus_init.storage %}
-        {%- for key in incus_init.storage[pool].local_config | default([]) %}
-
-          - entity: storage-pool
-            name: {{ pool }}
-            key: {{ key }}
-            value: {{ incus_init.storage[pool].local_config[key] }}
-        {%- endfor %}
-        {%- endfor %}
-        {%- for network in incus_init.network %}
-        {%- for key in incus_init.network[network].local_config | default([]) %}
-
-          - entity: network
-            name: {{ network }}
-            key: {{ key }}
-            value: {{ incus_init.network[network].local_config[key] }}
-        {%- endfor %}
-        {%- endfor %}
-  when: 'cluster_add.changed'
-  tags:
-    - skip_ansible_lint
+- name: Bootstrap the cluster
+  ansible.builtin.command: "incus --force-local cluster enable {{ inventory_hostname }}"
+  when: '(install_deb.changed or install_rpm.changed) and "cluster" in incus_roles and incus_servers[0] == inventory_hostname'
   changed_when: true
 
-- name: Apply additional configuration
-  ansible.builtin.command: "incus config set {{ item.key }}=\"{{ item.value }}\""
-  loop: "{{ incus_init['config'] | default({}) | dict2items }}"
-  when: >
-    (install_deb.changed or install_rpm.changed) and
-    ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname))
-  changed_when: true
-
-- name: Load client certificates
-  ansible.builtin.command:
-    cmd: "incus config trust add-certificate --name \"{{ item.key }}\" --type={{ item.value.type | default('client') }} -"
-    stdin: "{{ item.value.certificate }}"
-  loop: "{{ incus_init['clients'] | default({}) | dict2items }}"
-  when: >
-    (install_deb.changed or install_rpm.changed) and
-    ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname))'
+- name: Create join tokens
+  delegate_to: "{{ incus_servers[0] }}"
+  ansible.builtin.command: "incus --force-local --quiet cluster add {{ inventory_hostname }}"
+  register: cluster_add
+  notify:
+    - Wait 5s to avoid token use before valid
+    - Join the cluster
+  when: '(install_deb.changed or install_rpm.changed) and "cluster" in incus_roles and incus_servers[0] != inventory_hostname'
   changed_when: true

--- a/roles/incus/tasks/installation.yml
+++ b/roles/incus/tasks/installation.yml
@@ -142,29 +142,40 @@
     and item.value.description | default(None)
   changed_when: true
 
-# yamllint disable rule:line-length
 - name: Add storage pools
-  ansible.builtin.command: "incus storage create {{ item.key }} {{ item.value.driver }}{% for k in item.value.local_config | default([]) %} {{ k }}={{ item.value.local_config[k] }}{% endfor %}{% for k in item.value.config | default([]) %} {{ k }}={{ item.value.config[k] }}{% endfor %}"
+  ansible.builtin.command: >-
+    incus storage create {{ item.key }} {{ item.value.driver }}{% for k in item.value.local_config | default([]) %}
+    {{ k }}={{ item.value.local_config[k] }}{% endfor %}{% for k in item.value.config | default([]) %}
+    {{ k }}={{ item.value.config[k] }}{% endfor %}
   loop: "{{ incus_init['storage'] | dict2items }}"
-  when: '(install_deb.changed or install_rpm.changed) and ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname))'
+  when: >
+    (install_deb.changed or install_rpm.changed) and
+    ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname))
   changed_when: true
 
 - name: Set storage pool description
   ansible.builtin.command: "incus storage set --property {{ item.key }} description=\"{{ item.value.description }}\""
   loop: "{{ incus_init['storage'] | dict2items }}"
-  when: '(install_deb.changed or install_rpm.changed) and ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname)) and item.value.description | default(None)'
+  when: >
+    (install_deb.changed or install_rpm.changed) and
+    ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname)) and
+    item.value.description | default(None)
   changed_when: true
 
 - name: Add storage pool to default profile
   ansible.builtin.command: "incus profile device add default root disk path=/ pool={{ item }}"
   loop: "{{ incus_init['storage'] | dict2items | json_query('[?value.default].key') }}"
-  when: '(install_deb.changed or install_rpm.changed) and ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname))'
+  when: >
+    (install_deb.changed or install_rpm.changed) and
+    ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname))
   changed_when: true
 
 - name: Add network to default profile
   ansible.builtin.command: "incus profile device add default eth0 nic network={{ item }} name=eth0"
   loop: "{{ incus_init['network'] | dict2items | json_query('[?value.default].key') }}"
-  when: '(install_deb.changed or install_rpm.changed) and ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname))'
+  when: >
+    (install_deb.changed or install_rpm.changed) and
+    ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname))
   changed_when: true
 
 - name: Bootstrap the cluster
@@ -208,17 +219,25 @@
         cluster_address: "{{ incus_ip_address_or_default }}"
         cluster_token: "{{ cluster_add.stdout }}"
         server_address: "{{ incus_ip_address_or_default }}"
-        member_config: {% for pool in incus_init.storage %}{% for key in incus_init.storage[pool].local_config | default([]) %}
+        member_config:
+        {%- for pool in incus_init.storage %}
+        {%- for key in incus_init.storage[pool].local_config | default([]) %}
 
           - entity: storage-pool
             name: {{ pool }}
             key: {{ key }}
-            value: {{ incus_init.storage[pool].local_config[key] }}{% endfor %}{% endfor %}{% for network in incus_init.network %}{% for key in incus_init.network[network].local_config | default([]) %}
+            value: {{ incus_init.storage[pool].local_config[key] }}
+        {%- endfor %}
+        {%- endfor %}
+        {%- for network in incus_init.network %}
+        {%- for key in incus_init.network[network].local_config | default([]) %}
 
           - entity: network
             name: {{ network }}
             key: {{ key }}
-            value: {{ incus_init.network[network].local_config[key] }}{% endfor %}{% endfor %}
+            value: {{ incus_init.network[network].local_config[key] }}
+        {%- endfor %}
+        {%- endfor %}
   when: 'cluster_add.changed'
   tags:
     - skip_ansible_lint
@@ -227,7 +246,9 @@
 - name: Apply additional configuration
   ansible.builtin.command: "incus config set {{ item.key }}=\"{{ item.value }}\""
   loop: "{{ incus_init['config'] | default({}) | dict2items }}"
-  when: '(install_deb.changed or install_rpm.changed) and ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname))'
+  when: >
+    (install_deb.changed or install_rpm.changed) and
+    ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname))
   changed_when: true
 
 - name: Load client certificates
@@ -235,6 +256,7 @@
     cmd: "incus config trust add-certificate --name \"{{ item.key }}\" --type={{ item.value.type | default('client') }} -"
     stdin: "{{ item.value.certificate }}"
   loop: "{{ incus_init['clients'] | default({}) | dict2items }}"
-  when: '(install_deb.changed or install_rpm.changed) and ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname))'
+  when: >
+    (install_deb.changed or install_rpm.changed) and
+    ("standalone" in incus_roles or ("cluster" in incus_roles and incus_servers[0] == inventory_hostname))'
   changed_when: true
-# yamllint enable rule:line-length

--- a/roles/lvmcluster/handlers/configuration.yml
+++ b/roles/lvmcluster/handlers/configuration.yml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: Create cluster host_id tracking
+  delegate_to: 127.0.0.1
+  throttle: 1
+  ansible.builtin.copy:
+    content: "{}"
+    dest: "{{ lvmcluster_config_dir }}/{{ lvmcluster_name }}/host_id.yaml"
+    mode: "0644"
+  notify: Update cluster host_id tracking
+
+- name: Update cluster host_id tracking
+  delegate_to: 127.0.0.1
+  throttle: 1
+  ansible.builtin.template:
+    src: host_id.yaml.j2
+    dest: "{{ lvmcluster_config_dir }}/{{ lvmcluster_name }}/host_id.yaml"
+    mode: "0644"
+  vars:
+    lvmcluster_host_ids: "{{ lookup('file', lvmcluster_config_dir + '/' + lvmcluster_name + '/host_id.yaml') | from_yaml }}"

--- a/roles/lvmcluster/handlers/main.yml
+++ b/roles/lvmcluster/handlers/main.yml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: Manage configuration handlers
+  ansible.builtin.import_tasks: configuration.yml

--- a/roles/lvmcluster/tasks/configuration.yml
+++ b/roles/lvmcluster/tasks/configuration.yml
@@ -6,26 +6,4 @@
     state: directory
   throttle: 1
   when: 'lvmcluster_name'
-  register: create
-
-- name: Create cluster host_id tracking
-  delegate_to: 127.0.0.1
-  throttle: 1
-  ansible.builtin.copy:
-    content: "{}"
-    dest: "{{ lvmcluster_config_dir }}/{{ lvmcluster_name }}/host_id.yaml"
-    mode: "0644"
-  tags:
-    - skip_ansible_lint
-  when: "create.changed"
-
-- name: Update cluster host_id tracking
-  delegate_to: 127.0.0.1
-  throttle: 1
-  ansible.builtin.template:
-    src: host_id.yaml.j2
-    dest: "{{ lvmcluster_config_dir }}/{{ lvmcluster_name }}/host_id.yaml"
-    mode: "0644"
-  when: 'lvmcluster_name'
-  vars:
-    lvmcluster_host_ids: "{{ lookup('file', lvmcluster_config_dir + '/' + lvmcluster_name + '/host_id.yaml') | from_yaml }}"
+  notify: Create cluster host_id tracking

--- a/roles/lvmcluster/tasks/main.yml
+++ b/roles/lvmcluster/tasks/main.yml
@@ -3,6 +3,9 @@
 - name: Configure the cluster
   ansible.builtin.import_tasks: configuration.yml
 
+- name: Flush the handlers
+  ansible.builtin.meta: flush_handlers
+
 - name: Add the packages
   ansible.builtin.import_tasks: packages.yml
 

--- a/roles/lvmcluster/tasks/volumegroups.yml
+++ b/roles/lvmcluster/tasks/volumegroups.yml
@@ -17,7 +17,5 @@
 - name: Ensure lock manager is running
   ansible.builtin.command: "vgchange --lock-start"
   register: vgchange
-  when: "create.changed"
-  tags:
-    - skip_ansible_lint
   changed_when: "vgchange.rc == 0"
+  when: 'lvmcluster_name'


### PR DESCRIPTION
What this PR does is:
- fix the yaml and remove the yamlint disable rule
- fix the ansible linter issues in the lvmcluster role and remove the skip tag
- fix the ansible linter issues in the incus role and remove the skip tag