### PR TITLE
Fix issues detected with Incus 6.13 release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,8 +83,8 @@ jobs:
             sed -i -e '/linstor:/,+4d' hosts.yaml
           fi
 
-          if [ "${{ matrix.os }}" = "ubuntu/20.04" ]; then
-            # Ubuntu 20.04's OVN is too old.
+          if [ "${{ matrix.os }}" = "ubuntu/20.04" ] || [ "${{ matrix.os }}" = "ubuntu/22.04" ]; then
+            # Ubuntu 20.04 and 22.04's OVN are too old.
             sed -i "s/ovn_release:.*/ovn_release: \"ppa\"/g" hosts.yaml
           elif [ "${{ matrix.os }}" = "debian/12" ]; then
             # ZFS on Debian needs compiling which is slow, use btrfs instead

--- a/roles/incus/tasks/installation.yml
+++ b/roles/incus/tasks/installation.yml
@@ -186,6 +186,18 @@
   when: '(install_deb.changed or install_rpm.changed) and "cluster" in incus_roles and incus_servers[0] != inventory_hostname'
   changed_when: false
 
+- name: Set linstor controller_connection property
+  ansible.builtin.command: >-
+    incus --force-local config
+    set storage.linstor.controller_connection=http://{{ item }}:3370
+  loop: "{{ ansible_play_hosts }}"
+  register: register_linstor_controller
+  when: >-
+    "controller" in hostvars[item]["ansible_facts"]["linstor_roles"] and
+    ansible_distribution == "Ubuntu" and
+    ansible_distribution_release != "focal"
+  changed_when: "register_linstor_controller.rc == 0"
+
 - name: Join the cluster
   throttle: 1
   ansible.builtin.command:

--- a/roles/linstor/tasks/satellite.yml
+++ b/roles/linstor/tasks/satellite.yml
@@ -9,6 +9,20 @@
     existing_satellite_nodes: "{{ satellite_nodes_output.stdout | from_json | json_query('[].name') }}"
   when: '"controller" in linstor_roles'
 
+- name: Add controller node
+  ansible.builtin.command: >-
+    linstor node create {{ item }}
+    {{ hostvars[item].ansible_facts.default_ipv6.address | default(hostvars[item].ansible_facts.default_ipv4.address) }}
+    --node-type combined
+  register: create_node_output
+  loop: "{{ ansible_play_hosts }}"
+  when: >-
+    ("controller" in linstor_roles) and
+    ("satellite" in hostvars[item]["ansible_facts"]["linstor_roles"]) and
+    (item == inventory_hostname) and
+    (item not in existing_satellite_nodes)
+  changed_when: "create_node_output.rc == 0"
+
 - name: Add satellite nodes
   ansible.builtin.command: >-
     linstor node create {{ item }}
@@ -16,5 +30,9 @@
     --node-type satellite
   register: create_node_output
   loop: "{{ ansible_play_hosts }}"
-  when: '("controller" in linstor_roles) and ("satellite" in hostvars[item]["ansible_facts"]["linstor_roles"]) and (item not in existing_satellite_nodes)'
+  when: >-
+    ("controller" in linstor_roles) and
+    ("satellite" in hostvars[item]["ansible_facts"]["linstor_roles"]) and
+    (item != inventory_hostname) and
+    (item not in existing_satellite_nodes)
   changed_when: "create_node_output.rc == 0"

--- a/roles/lvmcluster/tasks/volumegroups.yml
+++ b/roles/lvmcluster/tasks/volumegroups.yml
@@ -12,11 +12,12 @@
   loop: "{{ check.results }}"
   run_once: true
   register: create
-  changed_when: true
+  changed_when: "create.rc == 0"
 
 - name: Ensure lock manager is running
   ansible.builtin.command: "vgchange --lock-start"
+  register: vgchange
   when: "create.changed"
   tags:
     - skip_ansible_lint
-  changed_when: true
+  changed_when: "vgchange.rc == 0"

--- a/roles/lvmcluster/templates/lvmlocal.conf.j2
+++ b/roles/lvmcluster/templates/lvmlocal.conf.j2
@@ -6,9 +6,11 @@ global {
 	use_lvmlockd = 1
 }
 
+{%- if ansible_distribution in ("CentOS", "Debian", "Ubuntu") and ansible_distribution_release not in ("jammy", "focal") %}
 devices {
 	use_devicesfile = 0
 }
+{%- endif %}
 
 local {
 	host_id = {{ lvmcluster_host_ids[inventory_hostname] }}


### PR DESCRIPTION
This PR addresses all the issues detected with the update of incus 6.13. The reason why we could not make every commit separate is because we need all the fixes to pass the tests.  It contains the following:

- set linstor controller_connection in incus 6.13, see [627efa42](https://github.com/lxc/incus-deploy/pull/63/commits/627efa4206d5e8669492c79fca25061c8b20be01): fixes #65 
- skip devices/use_devicesfile with ubuntu 20.04 and 22.04 see [2fb2ea5a](https://github.com/lxc/incus-deploy/pull/63/commits/2fb2ea5a01d4fbc5089e671a4c49c3af36b4c5be): fixes #64 
- Install OVN from ppa for Ubuntu 22.04 see [ff514f89](https://github.com/lxc/incus-deploy/pull/63/commits/ff514f89e986f2e53bf8a3c961cca5e04365e92a): fixes #62
 