### PR TITLE
register facts and fix standalone configuration in the incus role

### DIFF
--- a/roles/incus/tasks/main.yml
+++ b/roles/incus/tasks/main.yml
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
+- name: Set facts from variables for incus host queries
+  ansible.builtin.set_fact:
+    cacheable: true
+    incus_name: "{{ incus_name }}"
+    incus_roles: "{{ incus_roles }}"
+
 - name: Add the Debian repository registration
   ansible.builtin.import_tasks: "repo_deb.yml"
   when: 'ansible_distribution in ("Ubuntu", "Debian")'

--- a/roles/incus/templates/incus.servers.j2
+++ b/roles/incus/templates/incus.servers.j2
@@ -1,5 +1,10 @@
-{% for host in vars['ansible_play_hosts'] | sort %}
-{% if hostvars[host]['incus_name'] == incus_name and "cluster" in hostvars[host]['incus_roles'] %}
+{%- set found = namespace(count=0) %}
+{% for host in ansible_play_hosts | sort %}
+{% if hostvars[host]['incus_name'] | default('') == incus_name and "cluster" in hostvars[host]['incus_roles'] %}
+{% set found.count = found.count + 1 %}
 - {{ host }}
 {% endif %}
 {% endfor %}
+{%- if found.count == 0 %}
+[]
+{%- endif %}

--- a/roles/incus/templates/ovn-central.servers.j2
+++ b/roles/incus/templates/ovn-central.servers.j2
@@ -1,4 +1,4 @@
-{% for host in vars['ansible_play_hosts'] | sort %}
+{% for host in ansible_play_hosts | sort %}
 {% if hostvars[host]['ansible_facts']['ovn_name'] | default('') == ovn_name | default('') and hostvars[host]['ansible_facts']['ovn_az_name'] | default('') == ovn_az_name | default('') and "central" in hostvars[host]['ansible_facts']['ovn_roles'] | default([]) %}
 - "{{ hostvars[host]['ansible_facts']['ovn_ip_address'] | default(hostvars[host]['ansible_default_ipv6']['address'] | default(hostvars[host]['ansible_default_ipv4']['address'])) }}"
 {% endif %}


### PR DESCRIPTION
This PR:
- registers incus name and roles as facts so that we can query them even if we do not set variables in the host variables
- updates the `incus.servers.j2` file so that it returns an empty list when incus is installed in `standalone` mode.

Those 2 issues are not being tested on the CI but lead to failures in my case.