### PR TITLE
Fixing linstor storage pool creation when using different disk IDs

### DIFF
--- a/roles/linstor/defaults/main.yml
+++ b/roles/linstor/defaults/main.yml
@@ -3,4 +3,3 @@
 linstor_roles: []
 linstor_pool_name: "incus"
 linstor_pool_driver: "lvmthin"
-linstor_mapped_disks: []

--- a/roles/linstor/tasks/storage.yml
+++ b/roles/linstor/tasks/storage.yml
@@ -30,7 +30,13 @@
   ansible.builtin.command: >-
     linstor physical-storage create-device-pool --storage-pool {{ linstor_pool_name }}
     --pool-name linstor-{{ linstor_pool_name }} {{ linstor_pool_driver }} {{ item }}
-    {{ linstor_mapped_disks | join(' ') }}
+    {{
+      (
+        hostvars[item]["linstor_disks"] | default([])
+        | map('regex_replace', '^((?!/dev/disk/by-id/).*)$', '/dev/disk/by-id/\1')
+        | list
+      ) | join(' ')
+    }}
   register: linstor_create_storage_pool_output
   loop: "{{ ansible_play_hosts }}"
   when: >

--- a/roles/linstor/vars/main.yml
+++ b/roles/linstor/vars/main.yml
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
----
-linstor_mapped_disks: "{{ linstor_disks | default([]) | map('regex_replace', '^((?!/dev/disk/by-id/).*)$', '/dev/disk/by-id/\\1') | list }}"


### PR DESCRIPTION
When working with physical disks that have different IDs per node (e.g. nvme-CT1000P3PSSD8_XXXXXXXXXXXX-part4),
the logic here failed because the task was executed only on the control node which executed the storage
pool addition on all satellites, leading "{{ linstor_mapped_disks | join(' ') }}" to be rendered always as the
disk IDs from the control node. Obviously they are not present on the satellites. This is no issue, as long as
the disks have the same ID on all nodes (like in the example inventory "nvme-QEMU_NVMe_Ctrl_incus_disk5"). Since
vars/main.yml is only lazy-loaded when executing the task on each node, we can also get rid of the variable and
use the hostvars[item] from above to access the disk IDs. Not so clean any more, but functional.
I also replaced the double '\\' in the regex with a single one, otherwise disks IDs might be rendered empty.

Signed-off-by: Tim Beermann <tibeer@berryit.de>
